### PR TITLE
fix run_vm.sh's variable typo error - #8

### DIFF
--- a/guest_image/run_vm.sh
+++ b/guest_image/run_vm.sh
@@ -8,7 +8,7 @@ NR_CPU=$(grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}')
 
 # Default MEM_SIZE is half of total memory(MB).
 MEM_SIZE=$(grep MemTotal /proc/meminfo | awk '{print $2}')
-MEM_SZIE=$(( MEM_SIZE/2048 ))
+MEM_SIZE=$(( MEM_SIZE/2048 ))
 GUI_MODE=false
 
 function usage


### PR DESCRIPTION
Using the default memory size option(-m) cause a error. It's because
there is wrong name of variable. So fix "MEM_SZIE" to "MEM_SIZE"