### PR TITLE
Modify allocation of NUMA node in a sequential manner

### DIFF
--- a/Examples/memcpy_examples/memcpy.c
+++ b/Examples/memcpy_examples/memcpy.c
@@ -50,7 +50,7 @@ int prepare_memcpy(int threads, struct tdata **tdata) {
 #ifdef NUMA
 	source = numa_alloc_onnode(count * sizeof(uint64_t), numa_node_of_cpu(0));
 	#ifdef PERNODE
-	source2 = numa_alloc_onnode(count * sizeof(uint64_t), 1);
+	source2 = numa_alloc_onnode(count * sizeof(uint64_t), numa_node_of_cpu(num_proc()-1));
 	if(source2 == NULL){
 		perror("malloc");
 		return -1;
@@ -116,7 +116,7 @@ void *do_memcpy_numa(void *argp)
 #endif
 
 #ifdef PERNODE
-	if((tdata->tid %2)==0)
+	if(tdata->tid <= (num_proc()/2))
 		srcp = source;
 	else
 		srcp = source2;


### PR DESCRIPTION
Last commit, I divided the odd and even numbers and assigned them to the NUMA nodes,
like 0, 2, 4, ... -> node 0, and 1, 3, 5, ... -> node 1.
This time, I modified allocation of NUMA node in a sequential manner, so 0,1,2,... -> node 0 and the rest of half -> node 1.